### PR TITLE
Proof creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,15 +872,47 @@ dependencies = [
 
 [[package]]
 name = "ethers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f5a9d0b1503cceac3d434c671c8fe3294e5faf6e876958114fb80b91fdf2cea"
+dependencies = [
+ "ethers-contract 0.4.8",
+ "ethers-core 0.4.9",
+ "ethers-middleware 0.4.9",
+ "ethers-providers 0.4.7",
+ "ethers-signers 0.4.7",
+]
+
+[[package]]
+name = "ethers"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a61381751992e3806d338d83c0d321ac0d0414e42d4a22b38c9ba33f51b6d0"
 dependencies = [
- "ethers-contract",
- "ethers-core",
- "ethers-middleware",
- "ethers-providers",
- "ethers-signers",
+ "ethers-contract 0.5.1",
+ "ethers-core 0.5.1",
+ "ethers-middleware 0.5.1",
+ "ethers-providers 0.5.1",
+ "ethers-signers 0.5.1",
+]
+
+[[package]]
+name = "ethers-contract"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f22e4af812da76ff1e64ffd0a18af6ef7d150bc11bc605f080568d509bb86456"
+dependencies = [
+ "ethers-contract-abigen 0.4.8",
+ "ethers-contract-derive 0.4.8",
+ "ethers-core 0.4.9",
+ "ethers-providers 0.4.7",
+ "futures-util",
+ "hex",
+ "once_cell",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -889,10 +921,10 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4803df4be4adf66de6f0ab50f0717662de2c35b948bb94e422b53452257089d3"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-contract-derive",
- "ethers-core",
- "ethers-providers",
+ "ethers-contract-abigen 0.5.2",
+ "ethers-contract-derive 0.5.2",
+ "ethers-core 0.5.1",
+ "ethers-providers 0.5.1",
  "futures-util",
  "hex",
  "once_cell",
@@ -900,6 +932,29 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "ethers-contract-abigen"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df04337e59029f890c5f8eac32c07f5598647fffcf66a3929804b410b965f98"
+dependencies = [
+ "Inflector",
+ "anyhow",
+ "cargo_metadata",
+ "cfg-if 1.0.0",
+ "ethers-core 0.4.9",
+ "getrandom 0.2.3",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "syn",
+ "url",
 ]
 
 [[package]]
@@ -912,7 +967,7 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "cfg-if 1.0.0",
- "ethers-core",
+ "ethers-core 0.5.1",
  "getrandom 0.2.3",
  "hex",
  "once_cell",
@@ -927,17 +982,58 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "0.5.2"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf85a7e7b7b3b52aec1008c25efd357a848f79295bf0e31ba23c9dba234244a"
+checksum = "9cac31f49bff27f29a2915f4d680d6002ea78b34276dcdb11414b986924b60bc"
 dependencies = [
- "ethers-contract-abigen",
- "ethers-core",
+ "ethers-contract-abigen 0.4.8",
+ "ethers-core 0.4.9",
  "hex",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "ethers-contract-derive"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf85a7e7b7b3b52aec1008c25efd357a848f79295bf0e31ba23c9dba234244a"
+dependencies = [
+ "ethers-contract-abigen 0.5.2",
+ "ethers-core 0.5.1",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "ethers-core"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7458fee6a7fb651b5b9b89d8400067da1579aedad8561127e6f3380ecca5094"
+dependencies = [
+ "arrayvec 0.7.1",
+ "bytes",
+ "ecdsa",
+ "elliptic-curve",
+ "ethabi",
+ "futures-util",
+ "generic-array 0.14.4",
+ "glob",
+ "hex",
+ "k256",
+ "rand 0.8.4",
+ "rlp",
+ "rlp-derive",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tiny-keccak",
+ "tokio",
 ]
 
 [[package]]
@@ -968,15 +1064,39 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29d928f66a562d1be2dbef4f25c11c56513776c276c7b9e63f664241c8aa93f"
+dependencies = [
+ "async-trait",
+ "ethers-contract 0.4.8",
+ "ethers-core 0.4.9",
+ "ethers-providers 0.4.7",
+ "ethers-signers 0.4.7",
+ "futures-util",
+ "instant",
+ "reqwest",
+ "serde",
+ "serde-aux",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+]
+
+[[package]]
+name = "ethers-middleware"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1716346165ad6a4ffac9b308d4c33186982b1afd0f8968a48c4c97b0a40e382"
 dependencies = [
  "async-trait",
- "ethers-contract",
- "ethers-core",
- "ethers-providers",
- "ethers-signers",
+ "ethers-contract 0.5.1",
+ "ethers-core 0.5.1",
+ "ethers-providers 0.5.1",
+ "ethers-signers 0.5.1",
  "futures-util",
  "instant",
  "reqwest",
@@ -992,13 +1112,47 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43acc1313cbadbdeab1fef5205e8a86ad95e88b8210453f08b1f042c34300d56"
+dependencies = [
+ "async-trait",
+ "auto_impl",
+ "bytes",
+ "ethers-core 0.4.9",
+ "futures-channel",
+ "futures-core",
+ "futures-timer",
+ "futures-util",
+ "hex",
+ "parking_lot",
+ "pin-project",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-timer",
+ "web-sys",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "ethers-providers"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edfb15611b9514e7a8f5904ad3be15004efc6f4ecb40703b985d8fa1d5cc672"
 dependencies = [
  "async-trait",
  "auto_impl",
- "ethers-core",
+ "ethers-core 0.5.1",
  "futures-channel",
  "futures-core",
  "futures-timer",
@@ -1022,6 +1176,27 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e6a302ccf6784c9748d528f89f540d605a52fa7d0c81bda8bf3b3db3dc5ff"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "coins-ledger",
+ "elliptic-curve",
+ "eth-keystore",
+ "ethers-core 0.4.9",
+ "futures-executor",
+ "futures-util",
+ "hex",
+ "rand 0.8.4",
+ "sha2 0.9.5",
+ "thiserror",
+]
+
+[[package]]
+name = "ethers-signers"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75ded399aff63d9713112f0a60008ba32d214128fcad1525e1a775c7985f167e"
@@ -1032,7 +1207,7 @@ dependencies = [
  "coins-ledger",
  "elliptic-curve",
  "eth-keystore",
- "ethers-core",
+ "ethers-core 0.5.1",
  "futures-executor",
  "futures-util",
  "hex",
@@ -2318,7 +2493,7 @@ dependencies = [
  "anyhow",
  "argh",
  "colored",
- "ethers",
+ "ethers 0.5.2",
  "log",
  "radicle-tools",
  "tokio",
@@ -2331,7 +2506,7 @@ dependencies = [
  "anyhow",
  "coins-bip32",
  "colored",
- "ethers",
+ "ethers 0.5.2",
  "futures",
  "lexopt",
  "link-identities",
@@ -2339,6 +2514,24 @@ dependencies = [
  "multihash 0.14.0",
  "radicle-tools",
  "rpassword 5.0.1",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "rad-gpg"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "coins-bip32",
+ "colored",
+ "ethers 0.4.0",
+ "lexopt",
+ "log",
+ "radicle-tools",
+ "rpassword 5.0.1",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2695,6 +2888,18 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3308,6 +3513,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511de3f85caf1c98983545490c3d09685fa8eb634e57eec22bb4db271f46cbd8"
+dependencies = [
+ "futures-util",
+ "log",
+ "pin-project",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3383,6 +3605,28 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "tungstenite"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b2d8558abd2e276b0a8df5c05a2ec762609344191e5fd23e292c910e9165b5"
+dependencies = [
+ "base64 0.13.0",
+ "byteorder",
+ "bytes",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.4",
+ "rustls",
+ "rustls-native-certs",
+ "sha-1",
+ "thiserror",
+ "url",
+ "utf-8",
+ "webpki",
+]
 
 [[package]]
 name = "typenum"
@@ -3475,6 +3719,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ log = { version = "0.4", features = ["std"] }
 members = [
   "anchor",
   "account",
+  "proof-generator",
 ]
 
 [patch.crates-io.link-identities]

--- a/proof-generator/Cargo.toml
+++ b/proof-generator/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "proof-generator"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+anyhow = { version = "*" }
+log = { version = "0.4" }
+lexopt = { version = "0.1" }
+radicle-tools = { path = "../" }
+serde_json = { version = "1" }
+serde = { version = "1.0", features = ["derive"] }
+ethers = { version = "0", features = ["ledger"] }
+tokio = { version = "1.10", features = ["rt", "macros"] }
+rpassword = { version = "5.0" }
+thiserror = { version = "*" }
+colored = { version = "1.9" }
+coins-bip32 = { version = "*" }

--- a/proof-generator/USAGE
+++ b/proof-generator/USAGE
@@ -1,0 +1,20 @@
+Usage
+
+  proof-generator --gpg-key <string> --keystore <file> --rpc-url <url> --output <file> [<option>..] 
+
+Options
+
+    --gpg-key <string>           GPG key fingerprint
+    --keystore <file>            Path to keystore file
+    --ledger-hdpath <string>     HD Derivation path of Ledger HW
+    --rpc-url <url>              JSON-RPC URL of Ethereum node (eg. http://localhost:8545)
+    --output <file>              Path to where the proof should be stored
+    -v, --verbose                Verbose output
+    --help                       Show this message
+
+Example
+
+  proof-generator --gpg-key EB1729638209DCE61281F416504C9C1DE8C47EDF \
+             --rpc-url http://localhost:8545 \
+             --ledger-hdpath "m/44'/60'/0'/0/0" \
+             --output ./proof.json

--- a/proof-generator/src/lib.rs
+++ b/proof-generator/src/lib.rs
@@ -1,0 +1,177 @@
+use anyhow::anyhow;
+use coins_bip32::path::DerivationPath;
+use ethers::{
+    prelude::Signer,
+    providers::{Http, Middleware, Provider},
+    signers::{HDPath, Ledger},
+    types::{Signature, H256, H160},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    convert::TryFrom,
+    fmt::{Debug, Display},
+    fs,
+    io::Write,
+    path::PathBuf,
+    process::{Command, Stdio},
+    str,
+    borrow::Borrow,
+};
+
+/// The options allowed to be provided to the CLI
+#[derive(Debug, Clone)]
+pub struct Options {
+    /// GPG key to sign the proof.
+    pub gpg_key: String,
+    /// Output path of created proof
+    pub output: PathBuf,
+    /// RPC url
+    pub rpc_url: String,
+    /// Account derivation path when using a Ledger hardware wallet.
+    pub ledger_hdpath: Option<DerivationPath>,
+    /// Keystore file containing encrypted private key (default: none).
+    pub keystore: Option<PathBuf>,
+}
+
+/// Proof that a GPG key belongs to the same person as an Ethereum key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Proof {
+    /// Message to be signed by signee
+    message: String,
+    /// GPG signature of message
+    gpg_sig: String,
+    /// ETH signature of message
+    eth_sig: Signature,
+    /// GPG key fingerprint of the signee
+    gpg_key: String,
+    /// ETH address of the signee
+    eth_key: H160,
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// No wallet specified.
+    #[error("no wallet specified")]
+    NoWallet,
+    /// Not able to retrieve block .
+    #[error("not able to retrieve block")]
+    NoBlock,
+    /// Not able to retrieve block hash .
+    #[error("not able to retrieve block hash")]
+    NoBlockHash,
+    /// ETH signature failed
+    #[error("eth signature failed")]
+    ETHSigFailed,
+    /// GPG signature failed
+    #[error("{0}")]
+    GPGSigFailed(String),
+}
+
+/// Sign a message with a GPG private key using the GPG CLI
+fn gpg_sign(key: &str, message: &str) -> anyhow::Result<String> {
+    let mut gpg = Command::new("gpg")
+        .arg("--clear-sign")
+        .arg("-u")
+        .arg(key)
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()?;
+
+    gpg.stdin.as_mut().unwrap().write_all(message.as_bytes())?;
+
+    let output = gpg.wait_with_output()?;
+    if output.status.success() {
+        let raw_output = String::from_utf8_lossy(&output.stdout);
+        Ok(raw_output.to_string())
+    } else {
+        Err(anyhow!(Error::GPGSigFailed(String::from_utf8_lossy(
+            output.stderr.borrow()
+        ).to_string())))
+    }
+}
+
+/// Sign a message with a ETH private key using either a keystore file or a Ledger HW
+pub async fn eth_sign<S: 'static + Signer>(
+    signer: &S,
+    proof: &str,
+) -> Result<Signature, <S as Signer>::Error> {
+    signer.sign_message(proof).await
+}
+
+/// Create the proof to be signed
+fn create_message<T: Display, K: Debug>(
+    ownership: &T,
+    evidence: &K,
+    block_hash: &H256,
+) -> String {
+    format!(
+        "As the owner of GPG key {}, my Ethereum address is {:?} as of {:?}",
+        &ownership, &evidence, &block_hash
+    )
+}
+
+/// Sign the created proof with GPG and ETH keypairs
+async fn sign_proof<T: 'static + Signer>(
+    gpg_key: &str,
+    signer: &T,
+    block_hash: &H256,
+) -> anyhow::Result<Proof> {
+    let message = create_message(&gpg_key, &signer.address(), &block_hash);
+
+    log::info!("Signing message with ETH keypair..");
+    let eth_sig = eth_sign(signer, &message)
+        .await
+        .map_err(|_| anyhow!(Error::ETHSigFailed))?;
+    log::debug!("ETH Signature: {:?}.", eth_sig);
+
+    log::info!("Signing message with GPG keypair..");
+    let gpg_sig = gpg_sign(&gpg_key, &message)?;
+    log::debug!("GPG Signature: {:?}.", gpg_sig);
+
+    Ok(Proof { message, gpg_sig, eth_sig, gpg_key: gpg_key.to_string(), eth_key: signer.address() })
+}
+
+/// The main lib function that runs the functionality of the program
+/// - Obtains a block hash from a block from 1 day ago.
+/// - Gets either a keystore file or in its absence a Ledger HW as signer to sign a message.
+/// - Creates a message that will be signed by the defined signer.
+/// - Write both proofs to a JSON file.
+pub async fn run(opts: Options) -> anyhow::Result<()> {
+    let provider =
+        Provider::<Http>::try_from(opts.rpc_url).expect("could not instantiate HTTP Provider");
+    let latest_block_number = provider.get_block_number().await?;
+    // 5760 blocks earlier is aprox. 1 day ago, this due to avoid referencing blocks that are affected by reorgs of the chain.
+    let block_number= latest_block_number.saturating_sub(ethers::prelude::U64::from(5760));
+    let block = provider.get_block(block_number).await?.ok_or(anyhow!(Error::NoBlock))?;
+    // TODO: This is redundant eventually, since when a block is found by ethers-rs it must have a hash... I kept it to maintain the code style
+    let block_hash = block.hash.ok_or(anyhow!(Error::NoBlockHash))?; 
+    if let Some(keypath) = &opts.keystore {
+        use colored::*;
+
+        log::info!("Decrypting keystore..");
+        let prompt = format!("{} Password: ", "??".cyan());
+        let password = rpassword::prompt_password_stdout(&prompt).unwrap();
+        let signer = ethers::signers::LocalWallet::decrypt_keystore(keypath, password)
+            .map_err(|_| anyhow!("keystore decryption failed"))?;
+        log::debug!("Keystore decrypted: {:?}.", signer);
+
+        let proof = sign_proof(&opts.gpg_key, &signer, &block_hash).await?;
+        fs::write(&opts.output, serde_json::to_string(&proof)?)?;
+
+        Ok(())
+    } else if let Some(path) = &opts.ledger_hdpath {
+        log::info!("Connecting to Ledger..");
+
+        let hdpath = path.derivation_string();
+        let signer = Ledger::new(HDPath::Other(hdpath), 1).await?;
+        log::info!("Successfully connected to Ledger..");
+
+        let proof = sign_proof(&opts.gpg_key, &signer, &block_hash).await?;
+        fs::write(&opts.output, serde_json::to_string(&proof)?)?;
+
+        Ok(())
+    } else {
+        Err(anyhow!(Error::NoWallet))
+    }
+}

--- a/proof-generator/src/main.rs
+++ b/proof-generator/src/main.rs
@@ -1,0 +1,113 @@
+use anyhow::anyhow;
+use coins_bip32::path::DerivationPath;
+use proof_generator as proof;
+use radicle_tools::logger;
+use std::env;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process;
+
+const USAGE: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/", "USAGE"));
+const NAME: &str = env!("CARGO_CRATE_NAME");
+
+enum Command {
+    Run {
+        options: proof::Options,
+        verbose: bool,
+    },
+    Help,
+}
+
+fn parse_options() -> anyhow::Result<Command> {
+    use lexopt::prelude::*;
+
+    let mut parser = lexopt::Parser::from_env();
+    let mut gpg_key: Option<String> = None;
+    let mut output: Option<PathBuf> = None;
+    let mut rpc_url: Option<String> = None;
+    let mut ledger_hdpath: Option<DerivationPath> = None;
+    let mut keystore: Option<PathBuf> = None;
+    let mut verbose = false;
+
+    while let Some(arg) = parser.next()? {
+        match arg {
+            Long("gpg-key") => {
+                gpg_key = Some(parser.value()?.parse()?);
+            }
+            Long("output") => {
+                output = Some(parser.value()?.parse()?);
+            }
+            Long("keystore") => {
+                keystore = Some(parser.value()?.parse()?);
+            }
+            Long("ledger-hdpath") => {
+                ledger_hdpath = Some(parser.value()?.parse()?);
+            }
+            Long("rpc-url") => {
+                rpc_url = Some(parser.value()?.parse()?);
+            }
+            Long("verbose") | Short('v') => {
+                verbose = true;
+            }
+            Long("help") => {
+                return Ok(Command::Help);
+            }
+            _ => {
+                return Err(anyhow!(arg.unexpected()));
+            }
+        }
+    }
+
+    Ok(Command::Run {
+        options: proof::Options {
+            gpg_key: gpg_key
+                .ok_or_else(|| anyhow!("a gpg fingerprint must be specified with '--gpg-fpr'"))?,
+            output: output
+                .ok_or_else(|| anyhow!("an output path must be specified with '--output'"))?,
+            rpc_url: rpc_url
+                .ok_or_else(|| anyhow!("a json rpc provider must be specified with '--rpc-url'"))?,
+            ledger_hdpath,
+            keystore,
+        },
+        verbose,
+    })
+}
+
+#[tokio::main]
+async fn main() {
+    logger::init(NAME).unwrap();
+    logger::set_level(log::Level::Error);
+
+    match execute().await {
+        Err(err) => {
+            if let Some(&proof::Error::NoWallet) = err.downcast_ref() {
+                log::error!("Error: no wallet specified: either '--ledger-hdpath' or '--keystore' must be specified");
+            } else if let Some(cause) = err.source() {
+                log::error!("Error: {} ({})", err, cause);
+            } else {
+                log::error!("Error: {}", err);
+            }
+            process::exit(1);
+        }
+        Ok(()) => {}
+    }
+}
+
+async fn execute() -> anyhow::Result<()> {
+    match parse_options()? {
+        Command::Help => {
+            std::io::stderr().write_all(USAGE)?;
+            return Ok(());
+        }
+        Command::Run { options, verbose } => {
+            if verbose {
+                logger::set_level(log::Level::Debug);
+            } else {
+                logger::set_level(log::Level::Info);
+            }
+            proof::run(options).await?;
+        }
+    }
+    log::info!("Proof successfully created");
+    Ok(())
+}


### PR DESCRIPTION
This PR works on the creation of one-way proofs to link a GPG identity to a ETH address and vice versa.

It's still pretty much in alpha/beta so any feedback is welcome and specially from of a real cryptographer would not harm this PR.

In essence the new CLI allows a user using their GPG Long Key and a keystore file or a Ledger HW to sign two messages both showing that a specific GPG key corresponds to a specific ETH address, and for time relevance / revocation it injects a block hash to allow eventual future proofs to define which one came last.

This PR is based on https://github.com/radicle-dev/radicle-link/pull/557 and #2