### PR TITLE
push: follow source code pattern as other cmds

### DIFF
--- a/push/src/lib.rs
+++ b/push/src/lib.rs
@@ -1,8 +1,11 @@
 use std::ffi::OsString;
+use std::path::Path;
 
 use radicle_common::args::{Args, Error, Help};
+use radicle_common::git;
 use radicle_common::seed;
 use radicle_common::seed::SeedOptions;
+use radicle_terminal as term;
 
 use anyhow::anyhow;
 
@@ -108,4 +111,65 @@ impl Args for Options {
             vec![],
         ))
     }
+}
+
+pub fn run(options: Options, ctx: impl term::Context) -> anyhow::Result<()> {
+    ctx.profile()?;
+
+    term::info!("Pushing 🌱 to remote `rad`");
+
+    let repo = git::Repository::open(Path::new("."))?;
+    let head: Option<String> = repo
+        .head()
+        .ok()
+        .and_then(|head| head.shorthand().map(|h| h.to_owned()));
+
+    let mut args = vec!["push"];
+
+    if options.force {
+        args.push("--force");
+    }
+    if options.set_upstream {
+        args.push("--set-upstream");
+    }
+    if options.all {
+        args.push("--all");
+    }
+    if options.verbose {
+        args.push("--verbose");
+    }
+    args.push("rad"); // Push to "rad" remote.
+
+    term::subcommand(&format!("git {}", args.join(" ")));
+
+    // Push to monorepo.
+    match git::git(Path::new("."), args) {
+        Ok(output) => term::blob(output),
+        Err(err) => return Err(err),
+    }
+
+    if options.sync {
+        // Sync monorepo to seed.
+        rad_sync::run(
+            rad_sync::Options {
+                refs: if options.all {
+                    rad_sync::Refs::All
+                } else if let Some(head) = head {
+                    rad_sync::Refs::Branch(head)
+                } else {
+                    anyhow::bail!("You must be on a branch in order to push");
+                },
+                seed: options.seed,
+                identity: options.identity,
+                verbose: options.verbose,
+
+                fetch: false,
+                origin: None,
+                push_self: false,
+            },
+            ctx,
+        )?;
+    }
+
+    Ok(())
 }

--- a/src/bin/rad-push.rs
+++ b/src/bin/rad-push.rs
@@ -1,71 +1,7 @@
-use std::path::Path;
-
-use rad_push::HELP;
-use radicle_common::git;
+use rad_push::{run, Options, HELP};
 use radicle_terminal as term;
 
 // TODO: Pass all options after `--` to git.
 fn main() {
-    radicle_terminal::run_command::<rad_push::Options, _>(HELP, "Push", run);
-}
-
-fn run(options: rad_push::Options, ctx: impl term::Context) -> anyhow::Result<()> {
-    ctx.profile()?;
-
-    term::info!("Pushing 🌱 to remote `rad`");
-
-    let repo = git::Repository::open(Path::new("."))?;
-    let head: Option<String> = repo
-        .head()
-        .ok()
-        .and_then(|head| head.shorthand().map(|h| h.to_owned()));
-
-    let mut args = vec!["push"];
-
-    if options.force {
-        args.push("--force");
-    }
-    if options.set_upstream {
-        args.push("--set-upstream");
-    }
-    if options.all {
-        args.push("--all");
-    }
-    if options.verbose {
-        args.push("--verbose");
-    }
-    args.push("rad"); // Push to "rad" remote.
-
-    term::subcommand(&format!("git {}", args.join(" ")));
-
-    // Push to monorepo.
-    match git::git(Path::new("."), args) {
-        Ok(output) => term::blob(output),
-        Err(err) => return Err(err),
-    }
-
-    if options.sync {
-        // Sync monorepo to seed.
-        rad_sync::run(
-            rad_sync::Options {
-                refs: if options.all {
-                    rad_sync::Refs::All
-                } else if let Some(head) = head {
-                    rad_sync::Refs::Branch(head)
-                } else {
-                    anyhow::bail!("You must be on a branch in order to push");
-                },
-                seed: options.seed,
-                identity: options.identity,
-                verbose: options.verbose,
-
-                fetch: false,
-                origin: None,
-                push_self: false,
-            },
-            ctx,
-        )?;
-    }
-
-    Ok(())
+    term::run_command::<Options, _>(HELP, "Push", run);
 }


### PR DESCRIPTION
Move run(..) into push's create, as is done for all other commands.