### PR TITLE
common: Improve `Author` type

### DIFF
--- a/common/src/cobs/issue.rs
+++ b/common/src/cobs/issue.rs
@@ -856,13 +856,13 @@ mod test {
         let c1 = &issue.comments()[0];
 
         assert!(
-            matches!(&issue.author().identity, Identity::Resolved { identity } if identity.name == "cloudhead")
+            matches!(&issue.author().profile, Some(AuthorProfile { name, .. }) if name == "cloudhead")
         );
         assert!(
-            matches!(&issue.comment.author.identity, Identity::Resolved { identity } if identity.name == "cloudhead")
+            matches!(&issue.comment.author.profile, Some(AuthorProfile { name, .. }) if name == "cloudhead")
         );
         assert!(
-            matches!(&c1.author.identity, Identity::Resolved { identity } if identity.name == "cloudhead")
+            matches!(&c1.author.profile, Some(AuthorProfile { name, .. }) if name == "cloudhead")
         );
     }
 

--- a/common/src/project.rs
+++ b/common/src/project.rs
@@ -567,7 +567,7 @@ impl<'a> SetupRemote<'a> {
     }
 }
 
-fn deserialize_urn<'de, D>(deserializer: D) -> Result<Urn, D::Error>
+pub fn deserialize_urn<'de, D>(deserializer: D) -> Result<Urn, D::Error>
 where
     D: serde::Deserializer<'de>,
 {


### PR DESCRIPTION
We ensure that `Author` always has a `urn` at the top level.

Signed-off-by: Alexis Sellier <self@cloudhead.io>