### PR TITLE
Print the version only, without the name

### DIFF
--- a/cli/src/rad.rs
+++ b/cli/src/rad.rs
@@ -64,13 +64,14 @@ fn parse_args() -> anyhow::Result<Command> {
 
 fn print_version() {
     if VERSION.contains("-dev") {
-        println!("{} {}+{}", NAME, VERSION, GIT_HEAD)
+        println!("{}+{}", VERSION, GIT_HEAD)
     } else {
-        println!("{} {}", NAME, VERSION)
+        println!("{}", VERSION)
     }
 }
 
 fn print_help() -> anyhow::Result<()> {
+    print!("rad ");
     print_version();
     println!("{}", DESCRIPTION);
     println!();


### PR DESCRIPTION
Hey folks :wave:,

I'm the author and maintainer of https://github.com/cytechmobile/radicle-vscode-extension and came up to a tiny QoL issue with the CLI and thought I'd take a stab at it. Please note, this is the very first time I've ever touched Rust code, let alone contributing to this repo, so please help me double check I haven't broken everything! 😅

Before this change, invoking the CLI as `rad --version` would print something like `rad 0.6.1`. Notice that the output is not valid semver because it contains the `rad ` substring preceding the actual version number.

Because of this, clients of the CLI that want to interpolate the CLI version in a composed string e.g.:

```js
const log = `Using rad CLI v${getRadCliVersion()} from ${getRadCliPath()}`
```

will end up with the following as a result:

`Using rad CLI vrad 0.6.1 from /usr/bin/rad`

Note how we wanted to have `v0.6.1` and instead have `vrad 0.6.1`.

This commit fixes the above issue for the specific command `rad --version` while taking care that there are no side-effects to the output of other other existing commands.

If this PR makes no sense or is undesired in terms of product perspective, feel free to just close it, no worries. :)